### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-acme.sh-to-dockerhub.yml
+++ b/.github/workflows/publish-acme.sh-to-dockerhub.yml
@@ -21,7 +21,7 @@ jobs:
           echo "${{ env.RELEASE_VERSION_SUB }}"
           echo "${{ env.RELEASE_VERSION_MAIN }}"
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: halfcoke/acme.sh
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish-nextcloud-to-dockerhub-apache.yml
+++ b/.github/workflows/publish-nextcloud-to-dockerhub-apache.yml
@@ -21,7 +21,7 @@ jobs:
           echo "${{ env.RELEASE_VERSION_SUB }}"
           echo "${{ env.RELEASE_VERSION_MAIN }}"
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: halfcoke/nextcloud
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish-nextcloud-to-dockerhub.yml
+++ b/.github/workflows/publish-nextcloud-to-dockerhub.yml
@@ -21,7 +21,7 @@ jobs:
           echo "${{ env.RELEASE_VERSION_SUB }}"
           echo "${{ env.RELEASE_VERSION_MAIN }}"
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: halfcoke/nextcloud
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore